### PR TITLE
WIP: Refactor Playwright driver installation process

### DIFF
--- a/playwright-driver/default.nix
+++ b/playwright-driver/default.nix
@@ -63,7 +63,7 @@ let
 if [ -z "\$PLAYWRIGHT_NODEJS_PATH" ]; then
   PLAYWRIGHT_NODEJS_PATH="${nodejs}/bin/node"
 fi
-"\$PLAYWRIGHT_NODEJS_PATH" "$out/package/cli.js" "$@"
+"\$PLAYWRIGHT_NODEJS_PATH" "$out/package/cli.js" "\$@"
 EOF
 
         chmod +x $out/bin/playwright


### PR DESCRIPTION
Playwright 1.43.0 and higher don't ship the (fairly simple) playwright.sh. In this first version of a fix, we recreate it. However, this script is used only once later in the file, so maybe we want to skip creating it all together. 

However, this is used in Darwin only and I don't have access to a macOS device. If there is a macOS user who can help out with testing this change, that would be great. Otherwise I will ship it blindly because Linux users are affected, because this flake is currently broken.