### PR TITLE
feat: export a devshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ The [flake reference](https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-f
 -nix develop github:pietdevries94/playwright-web-flake
 +nix develop github:pietdevries94/playwright-web-flake/1.37.1
 ```
+
+## Also see
+
+- https://primamateria.github.io/blog/playwright-nixos-webdev/

--- a/README.md
+++ b/README.md
@@ -1,61 +1,94 @@
 # Playwright Web Flake
 
-This nix flake provides a way to install [Playwright](https://playwright.dev/) and its browsers in a nixos system.
+This nix flake provides a way to install [Playwright](https://playwright.dev/) and its browsers in a nixOS system.
 It does not contain playwright-python, because for my personal use I don't need it and it sometimes lags behind the latest version of playwright.
 
 ## Usage
 
-### nix shell
+See the [`nix shell`](#with-nix-shell) example if all you need is access to the `playwright` binary in the current shell.
+
+If you intend to run a test suite:
+
+- See the [`nix develop`](#with-nix-develop) example if the codebase you're working in does not already have a `flake.nix`, and you don't want to add one.
+- If the codebase already uses a flake.nix, adapt it like the flake.nix shown [below](#in-a-flake).
+
+### With `nix shell`
+
+Get access to the `playwright` binary in the current shell.
 
 ```sh
 nix shell github:pietdevries94/playwright-web-flake#playwright-test
+
+which playwright && playwright --version && playwright open nixos.org
+```
+
+### With `nix develop`
+
+Gets access to the `playwright` binary in the current shell and sets some playwright environment variables.
+
+```sh
+nix develop github:pietdevries94/playwright-web-flake
+
 which playwright && playwright --version && playwright open nixos.org
 ```
 
 ### In a flake
+
+1. Create a flake.nix with the content shown below.
+1. Enter the devshell with `nix develop`.
 
 ```nix
 {
   description = "Playwright development environment";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  inputs.playwright.url = "github:pietdevries94/playwright-web-flake"; # To set a custom version: "github:pietdevries94/playwright-web-flake/1.37.1"
+  inputs.playwright.url = "github:pietdevries94/playwright-web-flake";
 
-  outputs =
-    { self
-    , flake-utils
-    , nixpkgs
-    , playwright
-    }:
+  outputs = { self, flake-utils, nixpkgs, playwright }:
     flake-utils.lib.eachDefaultSystem (system:
-    let
-      overlay = final: prev: {
-        inherit (playwright.packages.${system}) playwright-test playwright-driver;
-      };
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ overlay ];
-      };
-    in
-    {
-      devShells = {
-        default = pkgs.mkShell {
-          packages = [
-            pkgs.playwright-test
-          ];
-          shellHook = ''
-            export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-            export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
-          '';
+      let
+        overlay = final: prev: {
+          inherit (playwright.packages.${system}) playwright-test playwright-driver;
         };
-      };
-    });
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+        };
+      in
+      {
+        devShells = {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.playwright-test
+            ];
+            shellHook = ''
+              export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+              export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+            '';
+          };
+        };
+      });
 }
 ```
-
-1. Create a flake.nix.
-1. Enter the development environment with `nix develop`.
 
 ## Versioning
 
 The update workflow tags the commit with the version of playwright that is installed. This version can be used to checkout the commit that installed that version of playwright, to match your environment.
+
+The list of available versions can be found [here](https://github.com/pietdevries94/playwright-web-flake/tags).
+
+The [flake reference](https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-flake.html#examples) can be modified to specify a custom version.
+
+### Example: specify a custom version in a flake
+
+```diff
+-inputs.playwright.url = "github:pietdevries94/playwright-web-flake";
++inputs.playwright.url = "github:pietdevries94/playwright-web-flake/1.37.1";
+```
+
+### Example: specify a custom version on the command line
+
+```diff
+-nix develop github:pietdevries94/playwright-web-flake
++nix develop github:pietdevries94/playwright-web-flake/1.37.1
+```

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,16 @@
           playwright-test = pkgs.callPackage ./playwright-test/wrapped.nix { };
           playwright-driver = pkgs.callPackage ./playwright-driver { };
         };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            self.packages.${system}.playwright-test
+          ];
+          shellHook = ''
+            export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+            export PLAYWRIGHT_BROWSERS_PATH="${self.packages.${system}.playwright-driver.browsers}"
+          '';
+        };
       }
     );
 }


### PR DESCRIPTION
Inspired by this reddit thread: https://www.reddit.com/r/NixOS/comments/1eyenzf/playwright_on_nixos_for_webdev/

---

This PR:

- exports a devshell that users can enter with `nix develop`. The devshell is identical to that created by the flake.nix shown in the readme. But instead of having to actually create the flake.nix file in the project then run `nix develop`, the devshell can just be entered with `nix develop github:pietdevries94/playwright-web-flake`.

- adds a couple of examples for how to specify an older version

- adds a link to a recent related blog post that was posted on r/NixOS
