### PR TITLE
Rename chrome binary and directory

### DIFF
--- a/playwright-driver/default.nix
+++ b/playwright-driver/default.nix
@@ -130,11 +130,11 @@ EOF
         BROWSERS_JSON=${driver}/package/browsers.json
       '' + lib.optionalString withChromium ''
         CHROMIUM_REVISION=$(jq -r '.browsers[] | select(.name == "chromium").revision' $BROWSERS_JSON)
-        mkdir -p $out/chromium-$CHROMIUM_REVISION/chrome-linux
+        mkdir -p $out/chromium_headless_shell-$CHROMIUM_REVISION/chrome-linux
 
         # See here for the Chrome options:
         # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
-        makeWrapper ${chromium}/bin/chromium $out/chromium-$CHROMIUM_REVISION/chrome-linux/chrome \
+        makeWrapper ${chromium}/bin/chromium $out/chromium_headless_shell-$CHROMIUM_REVISION/chrome-linux/headless_shell \
           --set SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
           --set FONTCONFIG_FILE ${fontconfig}
       '' + ''


### PR DESCRIPTION
The folder and executable names for the Chrome browser have changed from `chromium-XYZ` to `chromium_headless_shell-XYZ` with Playwright v1.49.1. This change causes the following error:

```
browserType.launch: Executable doesn't exist at /nix/store/s7kyjcq3mxaz9shv756zigid0l712yy0-playwright-browsers-chromium/chromium_headless_shell-1148/chrome-linux/headless_shell
```

The issue arises because Chromium has transitioned to a new headless implementation.
For more details, see https://github.com/microsoft/playwright/issues/33566.

This commit only renames the relevant files.
It is unclear if additional patches to the Chrome binary are necessary.

Fixes #11