### PR TITLE
fix: correct aarch64-linux headless shell browser path

### DIFF
--- a/playwright-driver/default.nix
+++ b/playwright-driver/default.nix
@@ -182,11 +182,11 @@ EOF
 
         # We also need to install the headless shell version of Chromium
         CHROMIUM_HEADLESS_SHELL_REVISION=$(jq -r '.browsers[] | select(.name == "chromium-headless-shell").revision' $BROWSERS_JSON)
-        mkdir -p $out/chromium-headless-shell-$CHROMIUM_HEADLESS_SHELL_REVISION/chrome-linux
+        mkdir -p $out/chromium_headless_shell-$CHROMIUM_HEADLESS_SHELL_REVISION/chrome-linux
 
         # See here for the Chrome options:
         # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
-        makeWrapper ${chromium}/bin/chromium $out/chromium_headless_shell-$CHROMIUM_REVISION/chrome-linux/chrome \
+        makeWrapper ${chromium}/bin/chromium $out/chromium_headless_shell-$CHROMIUM_HEADLESS_SHELL_REVISION/chrome-linux/headless_shell \
           --set SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
           --set FONTCONFIG_FILE ${fontconfig}
       '' + ''


### PR DESCRIPTION
The aarch64-linux headless shell browser was incorrectly configured:

1. mkdir used `chromium-headless-shell-` (dashes) but makeWrapper used `chromium_headless_shell-` (underscores) - now both use underscores

2. makeWrapper used $CHROMIUM_REVISION instead of $CHROMIUM_HEADLESS_SHELL_REVISION - now uses correct variable

3. Binary was named `chrome` instead of `headless_shell` - Playwright expects `headless_shell` at this path

Without this fix, Playwright fails on aarch64-linux with:
  Executable doesn't exist at .../chromium_headless_shell-1200/chrome-linux/headless_shell