### PR TITLE
Add playwright-mcp package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -33,9 +33,7 @@ jobs:
           new_driver=$(jq -r '.driver.version' versions.json)
           old_mcp=$(git show HEAD:versions.json | jq -r '.mcp.version')
           new_mcp=$(jq -r '.mcp.version' versions.json)
-          old_nixpkgs=$(git show HEAD:flake.lock | jq -r '.nodes.nixpkgs.locked.rev // "—"' | head -c 7)
-          new_nixpkgs=$(jq -r '.nodes.nixpkgs.locked.rev // "—"' flake.lock | head -c 7)
-
+          old_lock=$(git show HEAD:flake.lock)
           old_browsers=$(git show HEAD:playwright-driver/browsers.json)
           new_browsers=$(cat playwright-driver/browsers.json)
 
@@ -44,8 +42,17 @@ jobs:
           body+="| Package | Old | New |"$'\n'
           body+="|---------|-----|-----|"$'\n'
           body+="| Playwright driver | \`${old_driver}\` | \`${new_driver}\` |"$'\n'
-          body+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n'
-          body+="| nixpkgs | \`${old_nixpkgs}\` | \`${new_nixpkgs}\` |"$'\n\n'
+          body+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n\n'
+
+          body+="### Flake inputs"$'\n\n'
+          body+="| Input | Old | New |"$'\n'
+          body+="|-------|-----|-----|"$'\n'
+          for input in nixpkgs flake-utils; do
+            old_rev=$(echo "$old_lock" | jq -r ".nodes[\"${input}\"].locked.rev // \"—\"" | head -c 7)
+            new_rev=$(jq -r ".nodes[\"${input}\"].locked.rev // \"—\"" flake.lock | head -c 7)
+            body+="| ${input} | \`${old_rev}\` | \`${new_rev}\` |"$'\n'
+          done
+          body+=$'\n'
 
           body+="### Browser versions"$'\n\n'
           body+="| Browser | Old | New |"$'\n'
@@ -62,10 +69,7 @@ jobs:
           body+="- [Playwright v${new_driver}](https://github.com/microsoft/playwright/releases/tag/v${new_driver})"$'\n'
           body+="- [Playwright MCP v${new_mcp}](https://github.com/microsoft/playwright-mcp/releases/tag/v${new_mcp})"$'\n'
 
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "body<<$EOF" >> "$GITHUB_OUTPUT"
-          echo "$body" >> "$GITHUB_OUTPUT"
-          echo "$EOF" >> "$GITHUB_OUTPUT"
+          echo "$body" > /tmp/pr-body.md
       - name: Create Pull Request
         if: steps.changes.outputs.updated == 'true'
         env:
@@ -84,4 +88,4 @@ jobs:
           gh pr create \
             --title "Auto-update dependencies $(date +%Y-%m-%d)" \
             --label "auto-update" \
-            --body "${{ steps.summary.outputs.body }}"
+            --body-file /tmp/pr-body.md

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -80,6 +80,6 @@ jobs:
           git commit -m "Update to version ${version}"
           git push -u origin "$branch"
           gh pr create \
-            --title "Update playwright to v${version}" \
+            --title "Auto-update dependencies $(date +%Y-%m-%d)" \
             --label "auto-update" \
             --body "${{ steps.summary.outputs.body }}"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -70,7 +70,7 @@ jobs:
           body+="- [Playwright MCP v${new_mcp}](https://github.com/microsoft/playwright-mcp/releases/tag/v${new_mcp})"$'\n'
 
           echo "$body" > /tmp/pr-body.md
-      - name: Create Pull Request
+      - name: Create or update Pull Request
         if: steps.changes.outputs.updated == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,13 +79,18 @@ jobs:
           branch="auto-update/$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git branch -D "$branch" 2>/dev/null || true
-          git push origin --delete "$branch" 2>/dev/null || true
           git checkout -b "$branch"
           git add flake.lock versions.json playwright-driver/browsers.json
           git commit -m "Update to version ${version}"
-          git push -u origin "$branch"
-          gh pr create \
-            --title "Auto-update dependencies $(date +%Y-%m-%d)" \
-            --label "auto-update" \
-            --body-file /tmp/pr-body.md
+          git push --force -u origin "$branch"
+          existing_pr=$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" \
+              --title "Auto-update dependencies $(date +%Y-%m-%d)" \
+              --body-file /tmp/pr-body.md
+          else
+            gh pr create \
+              --title "Auto-update dependencies $(date +%Y-%m-%d)" \
+              --label "auto-update" \
+              --body-file /tmp/pr-body.md
+          fi

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -4,78 +4,78 @@ on:
   schedule:
     - cron: "0 0 * * *"
 jobs:
-  check-for-updates:
+  check-and-create-pr:
     runs-on: ubuntu-latest
-    outputs:
-      updated: ${{ steps.updated.outputs.updated }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./update.sh
-      - id: updated
-        run: cat updated.txt >> "$GITHUB_OUTPUT"
-
-  check-linux:
-    if: needs.check-for-updates.outputs.updated == 'true'
-    needs: check-for-updates
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./update.sh
-      - run: nix build .#playwright-driver
-      - run: nix flake check
-
-  check-darwin:
-    if: needs.check-for-updates.outputs.updated == 'true'
-    needs: check-for-updates
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: ./update.sh
-      - run: nix build .#playwright-driver
-      - run: nix flake check
-
-  push-updates:
-    needs: [check-for-updates, check-linux, check-darwin]
-    runs-on: ubuntu-latest
-
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
       contents: write
-
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: ./update.sh
-      - name: Set commit and tagging message
-        id: commit_message_step
+      - name: Check for changes
+        id: changes
         run: |
-          echo 'commit_message<<EOF' >> $GITHUB_OUTPUT
-          echo "Update to version $(cat version.txt)" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-          echo 'tagging_message<<EOF' >> $GITHUB_OUTPUT
-          cat version.txt >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: ${{ steps.commit_message_step.outputs.commit_message }}
-          tagging_message: ${{ steps.commit_message_step.outputs.tagging_message }}
+          if git diff --quiet versions.json playwright-driver/browsers.json 2>/dev/null; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build PR summary
+        if: steps.changes.outputs.updated == 'true'
+        id: summary
+        run: |
+          old_driver=$(git show HEAD:versions.json | jq -r '.driver.version')
+          new_driver=$(jq -r '.driver.version' versions.json)
+          old_mcp=$(git show HEAD:versions.json | jq -r '.mcp.version')
+          new_mcp=$(jq -r '.mcp.version' versions.json)
+
+          old_browsers=$(git show HEAD:playwright-driver/browsers.json)
+          new_browsers=$(cat playwright-driver/browsers.json)
+
+          body="## Summary"$'\n\n'
+          body+="### Core packages"$'\n\n'
+          body+="| Package | Old | New |"$'\n'
+          body+="|---------|-----|-----|"$'\n'
+          body+="| Playwright driver | \`${old_driver}\` | \`${new_driver}\` |"$'\n'
+          body+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n\n'
+
+          body+="### Browser versions"$'\n\n'
+          body+="| Browser | Old | New |"$'\n'
+          body+="|---------|-----|-----|"$'\n'
+
+          for browser in chromium firefox webkit; do
+            old_ver=$(echo "$old_browsers" | jq -r ".browsers[\"${browser}\"].browserVersion // \"—\"")
+            new_ver=$(echo "$new_browsers" | jq -r ".browsers[\"${browser}\"].browserVersion // \"—\"")
+            title=$(echo "$new_browsers" | jq -r ".browsers[\"${browser}\"].title // \"${browser}\"")
+            body+="| ${title} | \`${old_ver}\` | \`${new_ver}\` |"$'\n'
+          done
+
+          body+=$'\n'"### Release notes"$'\n\n'
+          body+="- [Playwright v${new_driver}](https://github.com/microsoft/playwright/releases/tag/v${new_driver})"$'\n'
+          body+="- [Playwright MCP v${new_mcp}](https://github.com/microsoft/playwright-mcp/releases/tag/v${new_mcp})"$'\n'
+
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "body<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "$body" >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
+      - name: Create Pull Request
+        if: steps.changes.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(cat version.txt)
+          branch="auto-update/v${version}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add versions.json playwright-driver/browsers.json
+          git commit -m "Update to version ${version}"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "Update playwright to v${version}" \
+            --label "auto-update" \
+            --body "${{ steps.summary.outputs.body }}"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -15,11 +15,12 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix flake update
       - run: ./update.sh
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet versions.json playwright-driver/browsers.json 2>/dev/null; then
+          if git diff --quiet flake.lock versions.json playwright-driver/browsers.json 2>/dev/null; then
             echo "updated=false" >> "$GITHUB_OUTPUT"
           else
             echo "updated=true" >> "$GITHUB_OUTPUT"
@@ -32,6 +33,8 @@ jobs:
           new_driver=$(jq -r '.driver.version' versions.json)
           old_mcp=$(git show HEAD:versions.json | jq -r '.mcp.version')
           new_mcp=$(jq -r '.mcp.version' versions.json)
+          old_nixpkgs=$(git show HEAD:flake.lock | jq -r '.nodes.nixpkgs.locked.rev // "—"' | head -c 7)
+          new_nixpkgs=$(jq -r '.nodes.nixpkgs.locked.rev // "—"' flake.lock | head -c 7)
 
           old_browsers=$(git show HEAD:playwright-driver/browsers.json)
           new_browsers=$(cat playwright-driver/browsers.json)
@@ -41,7 +44,8 @@ jobs:
           body+="| Package | Old | New |"$'\n'
           body+="|---------|-----|-----|"$'\n'
           body+="| Playwright driver | \`${old_driver}\` | \`${new_driver}\` |"$'\n'
-          body+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n\n'
+          body+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n'
+          body+="| nixpkgs | \`${old_nixpkgs}\` | \`${new_nixpkgs}\` |"$'\n\n'
 
           body+="### Browser versions"$'\n\n'
           body+="| Browser | Old | New |"$'\n'
@@ -72,7 +76,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
-          git add versions.json playwright-driver/browsers.json
+          git add flake.lock versions.json playwright-driver/browsers.json
           git commit -m "Update to version ${version}"
           git push -u origin "$branch"
           gh pr create \

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -106,13 +106,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          version=$(cat version.txt)
           branch="auto-update/$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add flake.lock versions.json playwright-driver/browsers.json
-          git commit -m "Update to version ${version}"
+          git commit -m "Auto-update dependencies $(date +%Y-%m-%d)" -m "$(cat /tmp/pr-body.md)"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push --force -u origin "$branch"
           existing_pr=$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -72,9 +72,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version=$(cat version.txt)
-          branch="auto-update/v${version}"
+          branch="auto-update/$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git branch -D "$branch" 2>/dev/null || true
+          git push origin --delete "$branch" 2>/dev/null || true
           git checkout -b "$branch"
           git add flake.lock versions.json playwright-driver/browsers.json
           git commit -m "Update to version ${version}"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Create or update Pull Request
         if: steps.changes.outputs.updated == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           version=$(cat version.txt)
           branch="auto-update/$(date +%Y-%m-%d)"
@@ -113,6 +113,7 @@ jobs:
           git checkout -b "$branch"
           git add flake.lock versions.json playwright-driver/browsers.json
           git commit -m "Update to version ${version}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push --force -u origin "$branch"
           existing_pr=$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')
           if [ -n "$existing_pr" ]; then

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -38,36 +38,67 @@ jobs:
           new_browsers=$(cat playwright-driver/browsers.json)
 
           body="## Summary"$'\n\n'
-          body+="### Core packages"$'\n\n'
-          body+="| Package | Old | New |"$'\n'
-          body+="|---------|-----|-----|"$'\n'
-          body+="| Playwright driver | \`${old_driver}\` | \`${new_driver}\` |"$'\n'
-          body+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n\n'
 
-          body+="### Flake inputs"$'\n\n'
-          body+="| Input | Old | New |"$'\n'
-          body+="|-------|-----|-----|"$'\n'
-          for input in nixpkgs flake-utils; do
-            old_rev=$(echo "$old_lock" | jq -r ".nodes[\"${input}\"].locked.rev // \"—\"" | head -c 7)
-            new_rev=$(jq -r ".nodes[\"${input}\"].locked.rev // \"—\"" flake.lock | head -c 7)
-            body+="| ${input} | \`${old_rev}\` | \`${new_rev}\` |"$'\n'
+          # Core packages section (only if something changed)
+          core_rows=""
+          if [ "$old_driver" != "$new_driver" ]; then
+            core_rows+="| Playwright driver | \`${old_driver}\` | \`${new_driver}\` |"$'\n'
+          fi
+          if [ "$old_mcp" != "$new_mcp" ]; then
+            core_rows+="| Playwright MCP | \`${old_mcp}\` | \`${new_mcp}\` |"$'\n'
+          fi
+          if [ -n "$core_rows" ]; then
+            body+="### Core packages"$'\n\n'
+            body+="| Package | Old | New |"$'\n'
+            body+="|---------|-----|-----|"$'\n'
+            body+="$core_rows"$'\n'
+          fi
+
+          # Flake inputs section (dynamically read inputs from flake.lock)
+          flake_rows=""
+          for input in $(jq -r '.nodes.root.inputs | keys[]' flake.lock); do
+            old_rev=$(echo "$old_lock" | jq -r ".nodes[\"${input}\"].locked.rev // empty" | head -c 7)
+            new_rev=$(jq -r ".nodes[\"${input}\"].locked.rev // empty" flake.lock | head -c 7)
+            if [ "$old_rev" != "$new_rev" ]; then
+              flake_rows+="| ${input} | \`${old_rev}\` | \`${new_rev}\` |"$'\n'
+            fi
           done
-          body+=$'\n'
+          if [ -n "$flake_rows" ]; then
+            body+="### Flake inputs"$'\n\n'
+            body+="| Input | Old | New |"$'\n'
+            body+="|-------|-----|-----|"$'\n'
+            body+="$flake_rows"$'\n'
+          fi
 
-          body+="### Browser versions"$'\n\n'
-          body+="| Browser | Old | New |"$'\n'
-          body+="|---------|-----|-----|"$'\n'
-
+          # Browser versions section (only changed browsers)
+          browser_rows=""
           for browser in chromium firefox webkit; do
             old_ver=$(echo "$old_browsers" | jq -r ".browsers[\"${browser}\"].browserVersion // \"—\"")
             new_ver=$(echo "$new_browsers" | jq -r ".browsers[\"${browser}\"].browserVersion // \"—\"")
-            title=$(echo "$new_browsers" | jq -r ".browsers[\"${browser}\"].title // \"${browser}\"")
-            body+="| ${title} | \`${old_ver}\` | \`${new_ver}\` |"$'\n'
+            if [ "$old_ver" != "$new_ver" ]; then
+              title=$(echo "$new_browsers" | jq -r ".browsers[\"${browser}\"].title // \"${browser}\"")
+              browser_rows+="| ${title} | \`${old_ver}\` | \`${new_ver}\` |"$'\n'
+            fi
           done
+          if [ -n "$browser_rows" ]; then
+            body+="### Browser versions"$'\n\n'
+            body+="| Browser | Old | New |"$'\n'
+            body+="|---------|-----|-----|"$'\n'
+            body+="$browser_rows"$'\n'
+          fi
 
-          body+=$'\n'"### Release notes"$'\n\n'
-          body+="- [Playwright v${new_driver}](https://github.com/microsoft/playwright/releases/tag/v${new_driver})"$'\n'
-          body+="- [Playwright MCP v${new_mcp}](https://github.com/microsoft/playwright-mcp/releases/tag/v${new_mcp})"$'\n'
+          # Release notes (only for changed packages)
+          notes=""
+          if [ "$old_driver" != "$new_driver" ]; then
+            notes+="- [Playwright v${new_driver}](https://github.com/microsoft/playwright/releases/tag/v${new_driver})"$'\n'
+          fi
+          if [ "$old_mcp" != "$new_mcp" ]; then
+            notes+="- [Playwright MCP v${new_mcp}](https://github.com/microsoft/playwright-mcp/releases/tag/v${new_mcp})"$'\n'
+          fi
+          if [ -n "$notes" ]; then
+            body+="### Release notes"$'\n\n'
+            body+="$notes"
+          fi
 
           echo "$body" > /tmp/pr-body.md
       - name: Create or update Pull Request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: "CI"
+on:
+  pull_request:
+jobs:
+  check-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix build .#playwright-driver
+      - run: nix flake check
+
+  check-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix build .#playwright-driver
+      - run: nix flake check
+
+  automerge:
+    runs-on: ubuntu-latest
+    needs: [check-linux, check-darwin]
+    permissions: write-all
+    if: contains(github.event.pull_request.labels.*.name, 'auto-update')
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.16.4
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   check-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -16,7 +16,7 @@ jobs:
   check-darwin:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,11 @@ name: "CI"
 on:
   pull_request:
 jobs:
-  check-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: nix build .#playwright-driver
-      - run: nix flake check
-
-  check-darwin:
-    runs-on: macos-latest
+  check:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -26,7 +18,7 @@ jobs:
 
   automerge:
     runs-on: ubuntu-latest
-    needs: [check-linux, check-darwin]
+    needs: [check]
     permissions: write-all
     if: contains(github.event.pull_request.labels.*.name, 'auto-update')
     steps:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,40 @@ nix develop github:pietdevries94/playwright-web-flake
 which playwright && playwright --version && playwright open nixos.org
 ```
 
+### Playwright MCP Server
+
+Run the [Playwright MCP server](https://github.com/Microsoft/playwright-mcp) for use with AI assistants like Claude.
+
+```sh
+nix shell github:pietdevries94/playwright-web-flake#playwright-mcp
+```
+
+Example configuration for Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "nix",
+      "args": ["shell", "github:pietdevries94/playwright-web-flake#playwright-mcp", "--command", "playwright-mcp", "--headless"]
+    }
+  }
+}
+```
+
+Example configuration for Claude Code (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "nix",
+      "args": ["shell", "github:pietdevries94/playwright-web-flake#playwright-mcp", "--command", "playwright-mcp", "--headless"]
+    }
+  }
+}
+```
+
 ### In a flake
 
 1. Create a flake.nix with the content shown below.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Run the [Playwright MCP server](https://github.com/Microsoft/playwright-mcp) for
 nix shell github:pietdevries94/playwright-web-flake#playwright-mcp
 ```
 
-Example configuration for Claude Desktop (`claude_desktop_config.json`):
+#### Configuration
+
+Add the following to your MCP configuration file:
 
 ```json
 {
@@ -56,18 +58,12 @@ Example configuration for Claude Desktop (`claude_desktop_config.json`):
 }
 ```
 
-Example configuration for Claude Code (`.mcp.json`):
+**Configuration file locations:**
 
-```json
-{
-  "mcpServers": {
-    "playwright": {
-      "command": "nix",
-      "args": ["shell", "github:pietdevries94/playwright-web-flake#playwright-mcp", "--command", "playwright-mcp", "--headless"]
-    }
-  }
-}
-```
+| Tool | Config File Path |
+|------|------------------|
+| Claude Desktop | `~/.config/claude/claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`) |
+| Claude Code | `.mcp.json` (in project root) |
 
 ### In a flake
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,11 @@
       in
       {
         packages = {
-          playwright-test = (pkgs.callPackage ./playwright-driver/driver.nix { }).playwright-test;
+          inherit ((pkgs.callPackage ./playwright-driver/driver.nix { })) playwright-test;
           playwright-driver = (pkgs.callPackage ./playwright-driver/driver.nix { }).playwright-core;
+          playwright-mcp = pkgs.callPackage ./playwright-mcp/package.nix {
+            inherit (self.packages.${system}) playwright-driver;
+          };
         };
 
         checks = {
@@ -35,6 +38,12 @@
           playwright-driver = pkgs.runCommand "check-playwright-driver" { } ''
             test -d "${self.packages.${system}.playwright-driver.browsers}"
             test $(ls "${self.packages.${system}.playwright-driver.browsers}" | wc -l) -gt 0
+            touch $out
+          '';
+          playwright-mcp = pkgs.runCommand "check-playwright-mcp" {
+            nativeBuildInputs = [ self.packages.${system}.playwright-mcp ];
+          } ''
+            playwright-mcp --help
             touch $out
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -18,34 +18,44 @@
         pkgs = import nixpkgs {
           inherit system;
         };
+        versions = pkgs.lib.importJSON ./versions.json;
+        playwright-driver-pkg = pkgs.callPackage ./playwright-driver/driver.nix { inherit versions; };
+        playwright-mcp = pkgs.callPackage ./playwright-mcp/package.nix {
+          inherit (self.packages.${system}) playwright-driver;
+          inherit versions;
+        };
       in
       {
         packages = {
-          inherit ((pkgs.callPackage ./playwright-driver/driver.nix { })) playwright-test;
-          playwright-driver = (pkgs.callPackage ./playwright-driver/driver.nix { }).playwright-core;
-          playwright-mcp = pkgs.callPackage ./playwright-mcp/package.nix {
-            inherit (self.packages.${system}) playwright-driver;
-          };
+          inherit playwright-mcp;
+          inherit (playwright-driver-pkg) playwright-test;
+          playwright-driver = playwright-driver-pkg.playwright-core;
         };
 
         checks = {
-          playwright-test = pkgs.runCommand "check-playwright-test" {
-            nativeBuildInputs = [ self.packages.${system}.playwright-test ];
-          } ''
-            playwright --version | grep "${self.packages.${system}.playwright-test.version}"
-            touch $out
-          '';
+          playwright-test =
+            pkgs.runCommand "check-playwright-test"
+              {
+                nativeBuildInputs = [ self.packages.${system}.playwright-test ];
+              }
+              ''
+                playwright --version | grep "${self.packages.${system}.playwright-test.version}"
+                touch $out
+              '';
           playwright-driver = pkgs.runCommand "check-playwright-driver" { } ''
             test -d "${self.packages.${system}.playwright-driver.browsers}"
             test $(ls "${self.packages.${system}.playwright-driver.browsers}" | wc -l) -gt 0
             touch $out
           '';
-          playwright-mcp = pkgs.runCommand "check-playwright-mcp" {
-            nativeBuildInputs = [ self.packages.${system}.playwright-mcp ];
-          } ''
-            playwright-mcp --help
-            touch $out
-          '';
+          playwright-mcp =
+            pkgs.runCommand "check-playwright-mcp"
+              {
+                nativeBuildInputs = [ self.packages.${system}.playwright-mcp ];
+              }
+              ''
+                playwright-mcp --help
+                touch $out
+              '';
         };
 
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,20 @@
           playwright-driver = (pkgs.callPackage ./playwright-driver/driver.nix { }).playwright-core;
         };
 
+        checks = {
+          playwright-test = pkgs.runCommand "check-playwright-test" {
+            nativeBuildInputs = [ self.packages.${system}.playwright-test ];
+          } ''
+            playwright --version | grep "${self.packages.${system}.playwright-test.version}"
+            touch $out
+          '';
+          playwright-driver = pkgs.runCommand "check-playwright-driver" { } ''
+            test -d "${self.packages.${system}.playwright-driver.browsers}"
+            test $(ls "${self.packages.${system}.playwright-driver.browsers}" | wc -l) -gt 0
+            touch $out
+          '';
+        };
+
         devShells.default = pkgs.mkShell {
           packages = [
             self.packages.${system}.playwright-test

--- a/playwright-driver/chromium-headless-shell.nix
+++ b/playwright-driver/chromium-headless-shell.nix
@@ -22,6 +22,7 @@
   libxkbcommon,
   nspr,
   nss,
+  hashes,
   ...
 }:
 let
@@ -35,12 +36,7 @@ let
         }
         .${system} or throwSystem;
       stripRoot = false;
-      hash =
-        {
-          x86_64-linux = "sha256-kQCw0nQHHuUIfn8rGVcN7Ip6ZOk5c3Or+GG5RvSica4=";
-          aarch64-linux = "sha256-s2IIjSY5t9AtT05dUS0mp4fPlaixND9+Cg0+0S8Kkx8=";
-        }
-        .${system} or throwSystem;
+      hash = hashes.${system} or throwSystem;
     };
 
     nativeBuildInputs = [
@@ -77,12 +73,7 @@ let
       }
       .${system} or throwSystem;
     stripRoot = false;
-    hash =
-      {
-        x86_64-darwin = "sha256-kzbLpzzMpBurQHyGaz561A0K46GzgWPP2JSQKRV6C+Y=";
-        aarch64-darwin = "sha256-67ekk37uq5ITq9ZvwPTZhhqEgQY17g/3KJ/vnqZz3h0=";
-      }
-      .${system} or throwSystem;
+    hash = hashes.${system} or throwSystem;
   };
 in
 {

--- a/playwright-driver/chromium.nix
+++ b/playwright-driver/chromium.nix
@@ -1,8 +1,6 @@
 {
-  runCommand,
   makeWrapper,
   fontconfig_file,
-  chromium,
   fetchzip,
   revision,
   browserVersion,

--- a/playwright-driver/chromium.nix
+++ b/playwright-driver/chromium.nix
@@ -37,6 +37,7 @@
   libXfixes,
   libXrandr,
   libxcb,
+  hashes,
   ...
 }:
 let
@@ -49,12 +50,7 @@ let
           aarch64-linux = "https://cdn.playwright.dev/builds/chromium/${revision}/chromium-${suffix}.zip";
         }
         .${system} or throwSystem;
-      hash =
-        {
-          x86_64-linux = "sha256-GtaJk9Qr1bTbDfpB+noGlLcIDEIS2uzDiV5rb2DZhVQ=";
-          aarch64-linux = "sha256-jsesQ6juzMPQzmn0Ygb8hmpxCeLHJVBL89qto5yuh5s=";
-        }
-        .${system} or throwSystem;
+      hash = hashes.${system} or throwSystem;
     };
 
     nativeBuildInputs = [
@@ -122,12 +118,7 @@ let
       }
       .${system} or throwSystem;
     stripRoot = false;
-    hash =
-      {
-        x86_64-darwin = "sha256-CxnLSe+sZYskO7H5f3cA+BlWCZsFOPpp1gVG5s37r80=";
-        aarch64-darwin = "sha256-n3JLK+hJwzPihC2qSHrSCYPz3jonZNz7GMgXiPBLaS0=";
-      }
-      .${system} or throwSystem;
+    hash = hashes.${system} or throwSystem;
   };
 in
 {

--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -10,6 +10,7 @@
   makeFontsConf,
   makeWrapper,
   cacert,
+  versions,
 }:
 let
   inherit (stdenv.hostPlatform) system;
@@ -24,20 +25,20 @@ let
     }
     .${system} or throwSystem;
 
-  version = "1.59.1";
+  inherit (versions.driver) version;
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright";
     rev = "v${version}";
-    hash = "sha256-kiH1jDyt5xMWc5C2dytoDC9fi1b5tWXZG8S6KEpuotM=";
+    inherit (versions.driver) hash;
   };
 
   babel-bundle = buildNpmPackage {
     pname = "babel-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright/bundles/babel";
-    npmDepsHash = "sha256-ByCy4go8PM0ksDg+2DcJPyoKG7Z0uIqKM647ZQwYwAE=";
+    npmDepsHash = versions.driver.npmDepsHashes."/packages/playwright/bundles/babel";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -47,7 +48,7 @@ let
     pname = "expect-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright/bundles/expect";
-    npmDepsHash = "sha256-PbPCsMqRkfU2c/mCsLSagew84XTgeO6H5+isNZQl2ek=";
+    npmDepsHash = versions.driver.npmDepsHashes."/packages/playwright/bundles/expect";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -57,7 +58,7 @@ let
     pname = "utils-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright/bundles/utils";
-    npmDepsHash = "sha256-BTaF1atpK+kG++ZJBUK4r3A7mbN2vv3xpDmb1NiNngE=";
+    npmDepsHash = versions.driver.npmDepsHashes."/packages/playwright/bundles/utils";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -67,7 +68,7 @@ let
     pname = "utils-bundle-core";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright-core/bundles/utils";
-    npmDepsHash = "sha256-O8X80rTT10ht97towSocANnGwH4fH1f3nZMSl8TOc+Y=";
+    npmDepsHash = versions.driver.npmDepsHashes."/packages/playwright-core/bundles/utils";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -77,7 +78,7 @@ let
     pname = "zip-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright-core/bundles/zip";
-    npmDepsHash = "sha256-5BHgCelIPh8ljIcdrO4AHafjqfLowDwJcpN+mD13Syw=";
+    npmDepsHash = versions.driver.npmDepsHashes."/packages/playwright-core/bundles/zip";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -88,8 +89,8 @@ let
     pname = "playwright";
     inherit version src;
 
-    sourceRoot = "${src.name}"; # update.sh depends on sourceRoot presence
-    npmDepsHash = "sha256-H3kKFthmZH4fqFPQA34w7iw2rubpEKLlJ9jaW6mpuyo=";
+    sourceRoot = "${src.name}";
+    npmDepsHash = versions.driver.npmDepsHashes."";
 
     nativeBuildInputs = [
       cacert
@@ -202,6 +203,7 @@ let
     chromium = callPackage ./chromium.nix {
       inherit suffix system throwSystem;
       inherit (playwright-core.passthru.browsersJSON.chromium) revision browserVersion;
+      hashes = versions.browsers.chromium;
       fontconfig_file = makeFontsConf {
         fontDirectories = [ ];
       };
@@ -209,18 +211,22 @@ let
     chromium-headless-shell = callPackage ./chromium-headless-shell.nix {
       inherit suffix system throwSystem;
       inherit (playwright-core.passthru.browsersJSON.chromium) revision browserVersion;
+      hashes = versions.browsers."chromium-headless-shell";
     };
     firefox = callPackage ./firefox.nix {
       inherit suffix system throwSystem;
       inherit (playwright-core.passthru.browsersJSON.firefox) revision;
+      hashes = versions.browsers.firefox;
     };
     webkit = callPackage ./webkit.nix {
       inherit suffix system throwSystem;
       inherit (playwright-core.passthru.browsersJSON.webkit) revision revisionOverrides;
+      hashes = versions.browsers.webkit;
     };
     ffmpeg = callPackage ./ffmpeg.nix {
       inherit suffix system throwSystem;
       inherit (playwright-core.passthru.browsersJSON.ffmpeg) revision revisionOverrides;
+      hashes = versions.browsers.ffmpeg;
     };
   };
 

--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -2,8 +2,6 @@
   lib,
   buildNpmPackage,
   stdenv,
-  chromium,
-  ffmpeg,
   jq,
   nodejs,
   fetchFromGitHub,
@@ -11,7 +9,6 @@
   callPackage,
   makeFontsConf,
   makeWrapper,
-  runCommand,
   cacert,
 }:
 let
@@ -152,7 +149,7 @@ let
     };
   };
 
-  playwright-core = stdenv.mkDerivation (finalAttrs: {
+  playwright-core = stdenv.mkDerivation (_: {
     pname = "playwright-core";
     inherit (playwright) version src meta;
 
@@ -176,7 +173,7 @@ let
     };
   });
 
-  playwright-test = stdenv.mkDerivation (finalAttrs: {
+  playwright-test = stdenv.mkDerivation (_: {
     pname = "playwright-test";
     inherit (playwright) version src;
 
@@ -234,9 +231,6 @@ let
       withWebkit ? true, # may require `export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu-24.04"`
       withFfmpeg ? true,
       withChromiumHeadlessShell ? true,
-      fontconfig_file ? makeFontsConf {
-        fontDirectories = [ ];
-      },
     }:
     let
       browsers =

--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -264,6 +264,6 @@ let
   );
 in
 {
-  playwright-core = playwright-core;
-  playwright-test = playwright-test;
+  inherit playwright-core;
+  inherit playwright-test;
 }

--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -24,13 +24,13 @@ let
     }
     .${system} or throwSystem;
 
-  version = "1.59.0";
+  version = "1.59.1";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright";
     rev = "v${version}";
-    hash = "sha256-RgP43A/NfiaPd/CmIBc0uzK69/IB0RH9Liv7tK/5rH4=";
+    hash = "sha256-kiH1jDyt5xMWc5C2dytoDC9fi1b5tWXZG8S6KEpuotM=";
   };
 
   babel-bundle = buildNpmPackage {
@@ -89,7 +89,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}"; # update.sh depends on sourceRoot presence
-    npmDepsHash = "sha256-GoKbwMBJR2UvN35xNz3+AqpC+jysy5La2Xpe2YU2InY=";
+    npmDepsHash = "sha256-H3kKFthmZH4fqFPQA34w7iw2rubpEKLlJ9jaW6mpuyo=";
 
     nativeBuildInputs = [
       cacert

--- a/playwright-driver/ffmpeg.nix
+++ b/playwright-driver/ffmpeg.nix
@@ -3,6 +3,7 @@
   suffix,
   revision,
   revisionOverrides ? { },
+  hashes,
   system,
   throwSystem,
 }:
@@ -26,12 +27,5 @@ in
 fetchzip {
   url = "https://cdn.playwright.dev/builds/ffmpeg/${revision'}/ffmpeg-${suffix}.zip";
   stripRoot = false;
-  hash =
-    {
-      x86_64-linux = "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=";
-      aarch64-linux = "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=";
-      x86_64-darwin = "sha256-ED6noxSDeEUt2DkIQ4gNe/kL+zHVeb2AD5klBk93F88=";
-      aarch64-darwin = "sha256-3Adnvb7zvMXKFOhb8uuj5kx0wEIFicmckYx9WLlNNf0=";
-    }
-    .${system} or throwSystem;
+  hash = hashes.${system} or throwSystem;
 }

--- a/playwright-driver/ffmpeg.nix
+++ b/playwright-driver/ffmpeg.nix
@@ -1,9 +1,8 @@
 {
-  lib,
   fetchzip,
   suffix,
   revision,
-  revisionOverrides ? {},
+  revisionOverrides ? { },
   system,
   throwSystem,
 }:

--- a/playwright-driver/firefox.nix
+++ b/playwright-driver/firefox.nix
@@ -5,6 +5,7 @@
   firefox-bin,
   suffix,
   revision,
+  hashes,
   system,
   throwSystem,
 }:
@@ -15,12 +16,7 @@ let
       url = "https://cdn.playwright.dev/builds/firefox/${revision}/firefox-${
         "ubuntu-22.04" + (lib.removePrefix "linux" suffix)
       }.zip";
-      hash =
-        {
-          x86_64-linux = "sha256-vbFI+7y3zayi5HmR1cTHPbcFCi6bvF3OVoAu8MygyEo=";
-          aarch64-linux = "sha256-7+C3fsIRVo4pfFOPgN7gD0P+fxC6juTMaTzjthq+mno=";
-        }
-        .${system} or throwSystem;
+      hash = hashes.${system} or throwSystem;
     };
 
     inherit (firefox-bin.unwrapped)
@@ -39,12 +35,7 @@ let
   firefox-darwin = fetchzip {
     url = "https://cdn.playwright.dev/builds/firefox/${revision}/firefox-${suffix}.zip";
     stripRoot = false;
-    hash =
-      {
-        x86_64-darwin = "sha256-OfNmamn82tJ8+eY6DC8a3AynmhObZ8E0GTegF8l7km4=";
-        aarch64-darwin = "sha256-WEYhmqGhGvO47i/OICJgXyqj64Wt52juJDEe7nD7HXU=";
-      }
-      .${system} or throwSystem;
+    hash = hashes.${system} or throwSystem;
   };
 in
 {

--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -50,6 +50,7 @@
   suffix,
   revision,
   revisionOverrides ? { },
+  hashes,
   system,
   throwSystem,
 }:
@@ -153,12 +154,7 @@ let
     src = fetchzip {
       url = "https://cdn.playwright.dev/builds/webkit/${revision'}/webkit-${suffix'}.zip";
       stripRoot = false;
-      hash =
-        {
-          x86_64-linux = "sha256-JdNYUUJPGRZ1Mdm2yTzFshsyntNlRqZCtyicLrrUk7g=";
-          aarch64-linux = "sha256-tQqaU1TuIfAohpMibWu9TVw9tVPZhXzYKZTZ5N7HqIk=";
-        }
-        .${system} or throwSystem;
+      hash = hashes.${system} or throwSystem;
     };
 
     nativeBuildInputs = [
@@ -235,12 +231,7 @@ let
   webkit-darwin = fetchzip {
     url = "https://cdn.playwright.dev/builds/webkit/${revision'}/webkit-${suffix'}.zip";
     stripRoot = false;
-    hash =
-      {
-        x86_64-darwin = "sha256-zmxdNdptFJ+8sad6HICoJRNsVNdQ0j4kKKCPX9YsBE8=";
-        aarch64-darwin = "sha256-AbDHuUg8jLNPWur6hieDdY8Kc2+PmlXRJGD46yujam4=";
-      }
-      .${system} or throwSystem;
+    hash = hashes.${system} or throwSystem;
   };
 in
 {

--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -19,6 +19,7 @@
   gst_all_1,
   harfbuzz,
   harfbuzzFull,
+  hyphen,
   icu70,
   lcms,
   libavif,
@@ -179,6 +180,7 @@ let
       gst_all_1.gstreamer
       harfbuzz
       harfbuzzFull
+      hyphen
       icu70
       lcms
       libavif'

--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -49,7 +49,7 @@
   zlib,
   suffix,
   revision,
-  revisionOverrides ? {},
+  revisionOverrides ? { },
   system,
   throwSystem,
 }:
@@ -78,7 +78,7 @@ let
     else
       suffix;
   libvpx' = libvpx.overrideAttrs (
-    finalAttrs: previousAttrs: {
+    finalAttrs: _: {
       version = "1.12.0";
       src = fetchFromGitHub {
         owner = "webmproject";
@@ -89,7 +89,7 @@ let
     }
   );
   libavif' = libavif.overrideAttrs (
-    finalAttrs: previousAttrs: {
+    finalAttrs: _: {
       version = "0.9.3";
       src = fetchFromGitHub {
         owner = "AOMediaCodec";
@@ -103,7 +103,7 @@ let
   );
 
   libjxl' = libjxl.overrideAttrs (
-    finalAttrs: previousAttrs: {
+    finalAttrs: _: {
       version = "0.8.2";
       src = fetchFromGitHub {
         owner = "libjxl";

--- a/playwright-mcp/package.nix
+++ b/playwright-mcp/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  playwright-driver,
+}:
+buildNpmPackage rec {
+  pname = "playwright-mcp";
+  version = "0.0.70";
+
+  src = fetchFromGitHub {
+    owner = "Microsoft";
+    repo = "playwright-mcp";
+    tag = "v${version}";
+    hash = "sha256-dvFFG+/cYy09RjEMDIWncTNCcyaKoKH52qweYq0HHxU=";
+  };
+
+  npmDepsHash = "sha256-tyVigQYA/viB8Ycg++SfPF6WEWWulnfuJXZYOBGhhOQ=";
+  npmWorkspace = "packages/playwright-mcp";
+
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail '"packages/*"' '"packages/playwright-mcp"'
+  '';
+
+  postInstall = ''
+    # Fix workspace symlinks: copy the workspace package into the expected location
+    local root="$out/lib/node_modules/playwright-mcp-internal"
+    rm -f "$root/node_modules/@playwright/mcp"
+    rm -f "$root/node_modules/.bin/playwright-mcp"
+    mkdir -p "$root/packages"
+    cp -r packages/playwright-mcp "$root/packages/"
+    ln -s "$root/packages/playwright-mcp" "$root/node_modules/@playwright/mcp"
+    ln -s "$root/packages/playwright-mcp/cli.js" "$root/node_modules/.bin/playwright-mcp"
+
+    wrapProgram $out/bin/playwright-mcp \
+      --set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers} \
+      --set-default PLAYWRIGHT_MCP_BROWSER chromium \
+      --run 'if [ -z "$PLAYWRIGHT_MCP_USER_DATA_DIR" ]; then PLAYWRIGHT_MCP_USER_DATA_DIR="$(mktemp -d -t mcp-pw-XXXXXX)"; export PLAYWRIGHT_MCP_USER_DATA_DIR; trap "rm -rf \"$PLAYWRIGHT_MCP_USER_DATA_DIR\"" EXIT; fi'
+  '';
+
+  dontNpmBuild = true;
+
+  meta = {
+    changelog = "https://github.com/Microsoft/playwright-mcp/releases/tag/v${version}";
+    description = "Playwright MCP server";
+    homepage = "https://github.com/Microsoft/playwright-mcp";
+    license = lib.licenses.asl20;
+    mainProgram = "playwright-mcp";
+  };
+}

--- a/playwright-mcp/package.nix
+++ b/playwright-mcp/package.nix
@@ -3,19 +3,20 @@
   buildNpmPackage,
   fetchFromGitHub,
   playwright-driver,
+  versions,
 }:
 buildNpmPackage rec {
   pname = "playwright-mcp";
-  version = "0.0.70";
+  inherit (versions.mcp) version;
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright-mcp";
     tag = "v${version}";
-    hash = "sha256-dvFFG+/cYy09RjEMDIWncTNCcyaKoKH52qweYq0HHxU=";
+    inherit (versions.mcp) hash;
   };
 
-  npmDepsHash = "sha256-tyVigQYA/viB8Ycg++SfPF6WEWWulnfuJXZYOBGhhOQ=";
+  inherit (versions.mcp) npmDepsHash;
   npmWorkspace = "packages/playwright-mcp";
 
   postPatch = ''
@@ -33,8 +34,21 @@ buildNpmPackage rec {
     rm -f "$root/node_modules/.bin/playwright-mcp"
     mkdir -p "$root/packages"
     cp -r packages/playwright-mcp "$root/packages/"
+    mkdir -p "$root/node_modules/@playwright"
+    mkdir -p "$root/node_modules/.bin"
     ln -s "$root/packages/playwright-mcp" "$root/node_modules/@playwright/mcp"
     ln -s "$root/packages/playwright-mcp/cli.js" "$root/node_modules/.bin/playwright-mcp"
+
+    # Fix symlinks in playwright-mcp-internal if it exists
+    local internal="$out/lib/node_modules/playwright-mcp-internal"
+    if [ -d "$internal" ]; then
+      rm -f "$internal/node_modules/@playwright/mcp"
+      rm -f "$internal/node_modules/.bin/playwright-mcp"
+      mkdir -p "$internal/node_modules/@playwright"
+      mkdir -p "$internal/node_modules/.bin"
+      ln -s "$root/packages/playwright-mcp" "$internal/node_modules/@playwright/mcp"
+      ln -s "$root/packages/playwright-mcp/cli.js" "$internal/node_modules/.bin/playwright-mcp"
+    fi
 
     wrapProgram $out/bin/playwright-mcp \
       --set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers} \

--- a/playwright-mcp/package.nix
+++ b/playwright-mcp/package.nix
@@ -24,8 +24,11 @@ buildNpmPackage rec {
   '';
 
   postInstall = ''
-    # Fix workspace symlinks: copy the workspace package into the expected location
-    local root="$out/lib/node_modules/playwright-mcp-internal"
+    # Fix workspace symlinks: copy the workspace package into the expected location.
+    # The workspace structure requires manual fixup because npm workspaces create
+    # symlinks that don't work in the Nix store. We copy the package into place
+    # and recreate the symlinks to make the CLI functional.
+    local root="$out/lib/node_modules/${pname}"
     rm -f "$root/node_modules/@playwright/mcp"
     rm -f "$root/node_modules/.bin/playwright-mcp"
     mkdir -p "$root/packages"

--- a/playwright-mcp/package.nix
+++ b/playwright-mcp/package.nix
@@ -17,39 +17,8 @@ buildNpmPackage rec {
   };
 
   inherit (versions.mcp) npmDepsHash;
-  npmWorkspace = "packages/playwright-mcp";
-
-  postPatch = ''
-    substituteInPlace package.json \
-      --replace-fail '"packages/*"' '"packages/playwright-mcp"'
-  '';
 
   postInstall = ''
-    # Fix workspace symlinks: copy the workspace package into the expected location.
-    # The workspace structure requires manual fixup because npm workspaces create
-    # symlinks that don't work in the Nix store. We copy the package into place
-    # and recreate the symlinks to make the CLI functional.
-    local root="$out/lib/node_modules/${pname}"
-    rm -f "$root/node_modules/@playwright/mcp"
-    rm -f "$root/node_modules/.bin/playwright-mcp"
-    mkdir -p "$root/packages"
-    cp -r packages/playwright-mcp "$root/packages/"
-    mkdir -p "$root/node_modules/@playwright"
-    mkdir -p "$root/node_modules/.bin"
-    ln -s "$root/packages/playwright-mcp" "$root/node_modules/@playwright/mcp"
-    ln -s "$root/packages/playwright-mcp/cli.js" "$root/node_modules/.bin/playwright-mcp"
-
-    # Fix symlinks in playwright-mcp-internal if it exists
-    local internal="$out/lib/node_modules/playwright-mcp-internal"
-    if [ -d "$internal" ]; then
-      rm -f "$internal/node_modules/@playwright/mcp"
-      rm -f "$internal/node_modules/.bin/playwright-mcp"
-      mkdir -p "$internal/node_modules/@playwright"
-      mkdir -p "$internal/node_modules/.bin"
-      ln -s "$root/packages/playwright-mcp" "$internal/node_modules/@playwright/mcp"
-      ln -s "$root/packages/playwright-mcp/cli.js" "$internal/node_modules/.bin/playwright-mcp"
-    fi
-
     wrapProgram $out/bin/playwright-mcp \
       --set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers} \
       --set-default PLAYWRIGHT_MCP_BROWSER chromium \

--- a/update.sh
+++ b/update.sh
@@ -8,11 +8,6 @@ root="$(dirname "$(readlink -f "$0")")"
 repo_root="$(git -C "$root" rev-parse --show-toplevel)"
 cd "$repo_root"
 
-github_api_curl_args=()
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-    github_api_curl_args=(-u ":$GITHUB_TOKEN")
-fi
-
 versions_file="$root/versions.json"
 playwright_browsers_file="$root/playwright-driver/browsers.json"
 playwright_raw_repo_url="https://raw.githubusercontent.com/microsoft/playwright"
@@ -20,14 +15,6 @@ driver_version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s https://api.g
 mcp_version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s https://api.github.com/repos/microsoft/playwright-mcp/releases/latest | jq -r '.tag_name | sub("^v"; "")')
 browser_names=(chromium chromium-headless-shell firefox webkit ffmpeg)
 browser_platforms=(linux darwin)
-
-github_api_get() {
-    curl "${github_api_curl_args[@]}" -fsSL "$1"
-}
-
-major_minor() {
-    echo "${1%.*}"
-}
 
 # Compute driver source hash
 driver_new_hash=$(nix-prefetch-github --rev "v$driver_version" "Microsoft" "playwright" | jq -r '.hash')

--- a/update.sh
+++ b/update.sh
@@ -15,8 +15,10 @@ fi
 
 playwright_browsers_file="$root/playwright-driver/browsers.json"
 playwright_driver_file="$root/playwright-driver/driver.nix"
+playwright_mcp_file="$root/playwright-mcp/package.nix"
 playwright_raw_repo_url="https://raw.githubusercontent.com/microsoft/playwright"
 driver_version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s https://api.github.com/repos/microsoft/playwright/releases/latest | jq -r '.tag_name | sub("^v"; "")')
+mcp_version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s https://api.github.com/repos/microsoft/playwright-mcp/releases/latest | jq -r '.tag_name | sub("^v"; "")')
 browser_names=(chromium chromium-headless-shell firefox webkit ffmpeg)
 browser_platforms=(linux darwin)
 
@@ -33,7 +35,9 @@ driver_new_hash=$(nix-prefetch-github --rev "v$driver_version" "Microsoft" "play
 sed -i "s|hash =\s*\"[^\$]*\"|hash = \"$driver_new_hash\"|" "$playwright_driver_file"
 
 temp_dir=$(mktemp -d)
-trap 'rm -rf "$temp_dir"' EXIT
+mcp_temp_dir=""
+cleanup() { rm -rf "$temp_dir" "$mcp_temp_dir"; }
+trap cleanup EXIT
 
 # update binaries of browsers, used by playwright.
 replace_sha() {
@@ -234,3 +238,17 @@ done < <(
     # shellcheck disable=SC2016
     sed -n 's#^[[:space:]]*sourceRoot = "${src.name}\(.*\)";.*$#\1#p' "$playwright_driver_file"
 )
+
+# Update playwright-mcp
+echo "Updating playwright-mcp to v${mcp_version}..."
+sed -i "s|version = \"[^\"]*\"|version = \"${mcp_version}\"|" "$playwright_mcp_file"
+mcp_new_hash=$(nix-prefetch-github --rev "v${mcp_version}" "Microsoft" "playwright-mcp" | jq -r '.hash')
+sed -i "s|hash = \"[^\"]*\"|hash = \"${mcp_new_hash}\"|" "$playwright_mcp_file"
+
+# Update playwright-mcp npmDepsHash
+mcp_temp_dir=$(mktemp -d)
+mcp_lock_url="https://raw.githubusercontent.com/microsoft/playwright-mcp/v${mcp_version}/package-lock.json"
+curl -fsSL -o "$mcp_temp_dir/package-lock.json" "$mcp_lock_url"
+mcp_npm_hash=$(prefetch-npm-deps "$mcp_temp_dir/package-lock.json")
+sed -i "s|npmDepsHash = \"[^\"]*\"|npmDepsHash = \"${mcp_npm_hash}\"|" "$playwright_mcp_file"
+echo "playwright-mcp updated to v${mcp_version}"

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused common-updater-scripts jq prefetch-npm-deps unzip nix-prefetch nix-prefetch-github
+#!nix-shell -i bash -p curl jq prefetch-npm-deps unzip nix-prefetch nix-prefetch-github
 # shellcheck shell=bash
 set -euo pipefail
 set -x
@@ -13,9 +13,8 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
     github_api_curl_args=(-u ":$GITHUB_TOKEN")
 fi
 
+versions_file="$root/versions.json"
 playwright_browsers_file="$root/playwright-driver/browsers.json"
-playwright_driver_file="$root/playwright-driver/driver.nix"
-playwright_mcp_file="$root/playwright-mcp/package.nix"
 playwright_raw_repo_url="https://raw.githubusercontent.com/microsoft/playwright"
 driver_version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s https://api.github.com/repos/microsoft/playwright/releases/latest | jq -r '.tag_name | sub("^v"; "")')
 mcp_version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s https://api.github.com/repos/microsoft/playwright-mcp/releases/latest | jq -r '.tag_name | sub("^v"; "")')
@@ -30,30 +29,18 @@ major_minor() {
     echo "${1%.*}"
 }
 
-sed -i "s|version =\s*\"[^\$]*\"|version = \"$driver_version\"|" "$playwright_driver_file"
+# Compute driver source hash
 driver_new_hash=$(nix-prefetch-github --rev "v$driver_version" "Microsoft" "playwright" | jq -r '.hash')
-sed -i "s|hash =\s*\"[^\$]*\"|hash = \"$driver_new_hash\"|" "$playwright_driver_file"
 
 temp_dir=$(mktemp -d)
 mcp_temp_dir=""
 cleanup() { rm -rf "$temp_dir" "$mcp_temp_dir"; }
 trap cleanup EXIT
 
-# update binaries of browsers, used by playwright.
-replace_sha() {
-    local target_file="$1"
-    local attr_name="$2"
-    local new_hash="$3"
-
-    sed -i "s|$attr_name = \".\{44,52\}\"|$attr_name = \"$new_hash\"|" "$target_file"
-}
-
 prefetch_browser() {
     local url="$1"
     local strip_root="$2"
 
-    # nix-prefetch is used to obtain sha with `stripRoot = false`
-    # doesn't work on macOS https://github.com/msteen/nix-prefetch/issues/53
     nix-prefetch --option extra-experimental-features flakes -q "{ stdenv, fetchzip }: stdenv.mkDerivation { name=\"browser\"; src = fetchzip { url = \"$url\"; stripRoot = $strip_root; }; }"
 }
 
@@ -64,7 +51,6 @@ get_revision() {
     local base_revision="$4"
     local override_key=""
 
-    # Determine the revision override key based on platform and arch
     if [ "$platform" = "darwin" ]; then
         if [ "$name" = "webkit" ]; then
             if [ "$arch" = "x86_64" ]; then
@@ -81,7 +67,6 @@ get_revision() {
         fi
     fi
 
-    # Check for revision override
     if [ -n "$override_key" ]; then
         local override_revision
         override_revision="$(jq -r ".browsers[\"$name\"].revisionOverrides[\"$override_key\"] // empty" "$playwright_browsers_file")"
@@ -105,8 +90,6 @@ browser_download_url() {
     local artifact
     local cft_platform
 
-    # Chromium and chromium-headless-shell use Chrome for Testing artifacts on
-    # Linux/macOS on x86_64 and aarch64-darwin.
     if [ "$name" = "chromium" ] || [ "$name" = "chromium-headless-shell" ]; then
         if [ "$name" = "chromium" ]; then
             artifact="chrome"
@@ -130,7 +113,6 @@ browser_download_url() {
         fi
     fi
 
-    # Webkit on darwin uses a different CDN path
     if [ "$name" = "webkit" ] && [ "$platform" = "darwin" ]; then
         echo "https://cdn.playwright.dev/builds/${buildname}/${revision}/${name}-${suffix}.zip"
         return
@@ -139,6 +121,9 @@ browser_download_url() {
     echo "https://cdn.playwright.dev/dbazure/download/playwright/builds/${buildname}/${revision}/${name}-${suffix}.zip"
 }
 
+# Declare associative array for browser hashes
+declare -A browser_hashes
+
 update_browser() {
     local name="$1"
     local platform="$2"
@@ -146,10 +131,7 @@ update_browser() {
     local suffix
     local aarch64_suffix
     local buildname
-    local revision
     local browser_version
-    local x86_64_url
-    local aarch64_url
 
     if [ "$platform" = "darwin" ]; then
         if [ "$name" = "webkit" ]; then
@@ -181,20 +163,21 @@ update_browser() {
     base_revision="$(jq -r ".browsers[\"$buildname\"].revision" "$playwright_browsers_file")"
     browser_version="$(jq -r ".browsers[\"$buildname\"].browserVersion // empty" "$playwright_browsers_file")"
 
-    # Get platform-specific revisions (handles revisionOverrides)
     local x86_64_revision
     local aarch64_revision
     x86_64_revision="$(get_revision "$name" "$platform" "x86_64" "$base_revision")"
     aarch64_revision="$(get_revision "$name" "$platform" "aarch64" "$base_revision")"
 
+    local x86_64_url
+    local aarch64_url
     x86_64_url="$(browser_download_url "$name" "$buildname" "$platform" "x86_64" "$x86_64_revision" "$browser_version" "$suffix")"
     aarch64_url="$(browser_download_url "$name" "$buildname" "$platform" "aarch64" "$aarch64_revision" "$browser_version" "$aarch64_suffix")"
-    replace_sha "$root/playwright-driver/$name.nix" "x86_64-$platform" \
-        "$(prefetch_browser "$x86_64_url" "$stripRoot")"
-    replace_sha "$root/playwright-driver/$name.nix" "aarch64-$platform" \
-        "$(prefetch_browser "$aarch64_url" "$stripRoot")"
+
+    browser_hashes["${name}.x86_64-${platform}"]="$(prefetch_browser "$x86_64_url" "$stripRoot")"
+    browser_hashes["${name}.aarch64-${platform}"]="$(prefetch_browser "$aarch64_url" "$stripRoot")"
 }
 
+# Update browsers.json from upstream
 curl -fsSL \
     "https://raw.githubusercontent.com/microsoft/playwright/v${driver_version}/packages/playwright-core/browsers.json" \
     | jq '
@@ -207,48 +190,137 @@ curl -fsSL \
       )
     ' > "$playwright_browsers_file"
 
+# Compute all browser hashes
 for platform in "${browser_platforms[@]}"; do
     for browser in "${browser_names[@]}"; do
         update_browser "$browser" "$platform"
     done
 done
 
-# Update package-lock.json files for all npm deps that are built in playwright
-
-# Download `package-lock.json` for a given sourceRoot path and update its hash.
-update_hash() {
-    local source_root_path="$1"
-    local download_url
-    local lock_file
-    local new_hash
-    local source_root_pattern
-
-    download_url="${playwright_raw_repo_url}/v${driver_version}${source_root_path}/package-lock.json"
-    lock_file="${temp_dir}/$(echo "$source_root_path" | tr '/.' '__').package-lock.json"
-    curl -fsSL -o "$lock_file" "$download_url"
-    new_hash=$(prefetch-npm-deps "$lock_file")
-
-    source_root_pattern=$(printf '%s\n' "$source_root_path" | sed 's/[][\\/.*^$+?(){}|]/\\&/g')
-    sed -E -i "/sourceRoot = \"\\\$\\{src.name\\}${source_root_pattern}\";/,/npmDepsHash = / s#npmDepsHash = \"[^\"]*\";#npmDepsHash = \"${new_hash}\";#" "$playwright_driver_file"
-}
-
-while IFS= read -r source_root_path; do
-    update_hash "$source_root_path"
-done < <(
-    # shellcheck disable=SC2016
-    sed -n 's#^[[:space:]]*sourceRoot = "${src.name}\(.*\)";.*$#\1#p' "$playwright_driver_file"
+# Compute npm dependency hashes for driver bundles
+declare -A npm_hashes
+npm_source_roots=(
+    "/packages/playwright/bundles/babel"
+    "/packages/playwright/bundles/expect"
+    "/packages/playwright/bundles/utils"
+    "/packages/playwright-core/bundles/utils"
+    "/packages/playwright-core/bundles/zip"
+    ""
 )
 
-# Update playwright-mcp
-echo "Updating playwright-mcp to v${mcp_version}..."
-sed -i "s|version = \"[^\"]*\"|version = \"${mcp_version}\"|" "$playwright_mcp_file"
-mcp_new_hash=$(nix-prefetch-github --rev "v${mcp_version}" "Microsoft" "playwright-mcp" | jq -r '.hash')
-sed -i "s|hash = \"[^\"]*\"|hash = \"${mcp_new_hash}\"|" "$playwright_mcp_file"
+for source_root_path in "${npm_source_roots[@]}"; do
+    if [ -n "$source_root_path" ]; then
+        download_url="${playwright_raw_repo_url}/v${driver_version}${source_root_path}/package-lock.json"
+    else
+        download_url="${playwright_raw_repo_url}/v${driver_version}/package-lock.json"
+    fi
+    lock_file="${temp_dir}/$(echo "$source_root_path" | tr '/.' '__').package-lock.json"
+    curl -fsSL -o "$lock_file" "$download_url"
+    # Use safe key by replacing / with _ for associative array
+    # Use "root" for empty path since bash doesn't allow empty string keys
+    if [ -n "$source_root_path" ]; then
+        safe_key=$(echo "$source_root_path" | tr '/' '_')
+    else
+        safe_key="root"
+    fi
+    npm_hashes["$safe_key"]=$(prefetch-npm-deps "$lock_file")
+done
 
-# Update playwright-mcp npmDepsHash
+# Compute MCP hashes
+echo "Updating playwright-mcp to v${mcp_version}..."
+mcp_new_hash=$(nix-prefetch-github --rev "v${mcp_version}" "Microsoft" "playwright-mcp" | jq -r '.hash')
 mcp_temp_dir=$(mktemp -d)
 mcp_lock_url="https://raw.githubusercontent.com/microsoft/playwright-mcp/v${mcp_version}/package-lock.json"
 curl -fsSL -o "$mcp_temp_dir/package-lock.json" "$mcp_lock_url"
 mcp_npm_hash=$(prefetch-npm-deps "$mcp_temp_dir/package-lock.json")
-sed -i "s|npmDepsHash = \"[^\"]*\"|npmDepsHash = \"${mcp_npm_hash}\"|" "$playwright_mcp_file"
+
+# Build versions.json with all computed values
+jq -n \
+    --arg driver_version "$driver_version" \
+    --arg driver_hash "$driver_new_hash" \
+    --arg npm_babel "${npm_hashes["_packages_playwright_bundles_babel"]}" \
+    --arg npm_expect "${npm_hashes["_packages_playwright_bundles_expect"]}" \
+    --arg npm_utils "${npm_hashes["_packages_playwright_bundles_utils"]}" \
+    --arg npm_utils_core "${npm_hashes["_packages_playwright-core_bundles_utils"]}" \
+    --arg npm_zip "${npm_hashes["_packages_playwright-core_bundles_zip"]}" \
+    --arg npm_root "${npm_hashes["root"]}" \
+    --arg chromium_x86_64_linux "${browser_hashes["chromium.x86_64-linux"]}" \
+    --arg chromium_aarch64_linux "${browser_hashes["chromium.aarch64-linux"]}" \
+    --arg chromium_x86_64_darwin "${browser_hashes["chromium.x86_64-darwin"]}" \
+    --arg chromium_aarch64_darwin "${browser_hashes["chromium.aarch64-darwin"]}" \
+    --arg chromium_hs_x86_64_linux "${browser_hashes["chromium-headless-shell.x86_64-linux"]}" \
+    --arg chromium_hs_aarch64_linux "${browser_hashes["chromium-headless-shell.aarch64-linux"]}" \
+    --arg chromium_hs_x86_64_darwin "${browser_hashes["chromium-headless-shell.x86_64-darwin"]}" \
+    --arg chromium_hs_aarch64_darwin "${browser_hashes["chromium-headless-shell.aarch64-darwin"]}" \
+    --arg firefox_x86_64_linux "${browser_hashes["firefox.x86_64-linux"]}" \
+    --arg firefox_aarch64_linux "${browser_hashes["firefox.aarch64-linux"]}" \
+    --arg firefox_x86_64_darwin "${browser_hashes["firefox.x86_64-darwin"]}" \
+    --arg firefox_aarch64_darwin "${browser_hashes["firefox.aarch64-darwin"]}" \
+    --arg webkit_x86_64_linux "${browser_hashes["webkit.x86_64-linux"]}" \
+    --arg webkit_aarch64_linux "${browser_hashes["webkit.aarch64-linux"]}" \
+    --arg webkit_x86_64_darwin "${browser_hashes["webkit.x86_64-darwin"]}" \
+    --arg webkit_aarch64_darwin "${browser_hashes["webkit.aarch64-darwin"]}" \
+    --arg ffmpeg_x86_64_linux "${browser_hashes["ffmpeg.x86_64-linux"]}" \
+    --arg ffmpeg_aarch64_linux "${browser_hashes["ffmpeg.aarch64-linux"]}" \
+    --arg ffmpeg_x86_64_darwin "${browser_hashes["ffmpeg.x86_64-darwin"]}" \
+    --arg ffmpeg_aarch64_darwin "${browser_hashes["ffmpeg.aarch64-darwin"]}" \
+    --arg mcp_version "$mcp_version" \
+    --arg mcp_hash "$mcp_new_hash" \
+    --arg mcp_npm_hash "$mcp_npm_hash" \
+    '{
+      driver: {
+        version: $driver_version,
+        hash: $driver_hash,
+        npmDepsHashes: {
+          "/packages/playwright/bundles/babel": $npm_babel,
+          "/packages/playwright/bundles/expect": $npm_expect,
+          "/packages/playwright/bundles/utils": $npm_utils,
+          "/packages/playwright-core/bundles/utils": $npm_utils_core,
+          "/packages/playwright-core/bundles/zip": $npm_zip,
+          "": $npm_root
+        }
+      },
+      browsers: {
+        chromium: {
+          "x86_64-linux": $chromium_x86_64_linux,
+          "aarch64-linux": $chromium_aarch64_linux,
+          "x86_64-darwin": $chromium_x86_64_darwin,
+          "aarch64-darwin": $chromium_aarch64_darwin
+        },
+        "chromium-headless-shell": {
+          "x86_64-linux": $chromium_hs_x86_64_linux,
+          "aarch64-linux": $chromium_hs_aarch64_linux,
+          "x86_64-darwin": $chromium_hs_x86_64_darwin,
+          "aarch64-darwin": $chromium_hs_aarch64_darwin
+        },
+        firefox: {
+          "x86_64-linux": $firefox_x86_64_linux,
+          "aarch64-linux": $firefox_aarch64_linux,
+          "x86_64-darwin": $firefox_x86_64_darwin,
+          "aarch64-darwin": $firefox_aarch64_darwin
+        },
+        webkit: {
+          "x86_64-linux": $webkit_x86_64_linux,
+          "aarch64-linux": $webkit_aarch64_linux,
+          "x86_64-darwin": $webkit_x86_64_darwin,
+          "aarch64-darwin": $webkit_aarch64_darwin
+        },
+        ffmpeg: {
+          "x86_64-linux": $ffmpeg_x86_64_linux,
+          "aarch64-linux": $ffmpeg_aarch64_linux,
+          "x86_64-darwin": $ffmpeg_x86_64_darwin,
+          "aarch64-darwin": $ffmpeg_aarch64_darwin
+        }
+      },
+      mcp: {
+        version: $mcp_version,
+        hash: $mcp_hash,
+        npmDepsHash: $mcp_npm_hash
+      }
+    }' > "$versions_file"
+
 echo "playwright-mcp updated to v${mcp_version}"
+echo "All versions written to versions.json"
+
+# Write version for commit message
+echo "${driver_version}" > version.txt

--- a/versions.json
+++ b/versions.json
@@ -44,8 +44,8 @@
     }
   },
   "mcp": {
-    "version": "0.0.70",
-    "hash": "sha256-dvFFG+/cYy09RjEMDIWncTNCcyaKoKH52qweYq0HHxU=",
-    "npmDepsHash": "sha256-tyVigQYA/viB8Ycg++SfPF6WEWWulnfuJXZYOBGhhOQ="
+    "version": "0.0.71",
+    "hash": "sha256-C4tXXpIbGdgedy5IdUi2xeSQwAo4v+++PC7rznX2sMc=",
+    "npmDepsHash": "sha256-MKCldBLhxEa4g9A3crj48bRbBfbnGbEntvf3aTgqYII="
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,51 @@
+{
+  "driver": {
+    "version": "1.59.1",
+    "hash": "sha256-kiH1jDyt5xMWc5C2dytoDC9fi1b5tWXZG8S6KEpuotM=",
+    "npmDepsHashes": {
+      "/packages/playwright/bundles/babel": "sha256-ByCy4go8PM0ksDg+2DcJPyoKG7Z0uIqKM647ZQwYwAE=",
+      "/packages/playwright/bundles/expect": "sha256-PbPCsMqRkfU2c/mCsLSagew84XTgeO6H5+isNZQl2ek=",
+      "/packages/playwright/bundles/utils": "sha256-BTaF1atpK+kG++ZJBUK4r3A7mbN2vv3xpDmb1NiNngE=",
+      "/packages/playwright-core/bundles/utils": "sha256-O8X80rTT10ht97towSocANnGwH4fH1f3nZMSl8TOc+Y=",
+      "/packages/playwright-core/bundles/zip": "sha256-5BHgCelIPh8ljIcdrO4AHafjqfLowDwJcpN+mD13Syw=",
+      "": "sha256-H3kKFthmZH4fqFPQA34w7iw2rubpEKLlJ9jaW6mpuyo="
+    }
+  },
+  "browsers": {
+    "chromium": {
+      "x86_64-linux": "sha256-GtaJk9Qr1bTbDfpB+noGlLcIDEIS2uzDiV5rb2DZhVQ=",
+      "aarch64-linux": "sha256-jsesQ6juzMPQzmn0Ygb8hmpxCeLHJVBL89qto5yuh5s=",
+      "x86_64-darwin": "sha256-CxnLSe+sZYskO7H5f3cA+BlWCZsFOPpp1gVG5s37r80=",
+      "aarch64-darwin": "sha256-n3JLK+hJwzPihC2qSHrSCYPz3jonZNz7GMgXiPBLaS0="
+    },
+    "chromium-headless-shell": {
+      "x86_64-linux": "sha256-kQCw0nQHHuUIfn8rGVcN7Ip6ZOk5c3Or+GG5RvSica4=",
+      "aarch64-linux": "sha256-s2IIjSY5t9AtT05dUS0mp4fPlaixND9+Cg0+0S8Kkx8=",
+      "x86_64-darwin": "sha256-kzbLpzzMpBurQHyGaz561A0K46GzgWPP2JSQKRV6C+Y=",
+      "aarch64-darwin": "sha256-67ekk37uq5ITq9ZvwPTZhhqEgQY17g/3KJ/vnqZz3h0="
+    },
+    "firefox": {
+      "x86_64-linux": "sha256-vbFI+7y3zayi5HmR1cTHPbcFCi6bvF3OVoAu8MygyEo=",
+      "aarch64-linux": "sha256-7+C3fsIRVo4pfFOPgN7gD0P+fxC6juTMaTzjthq+mno=",
+      "x86_64-darwin": "sha256-OfNmamn82tJ8+eY6DC8a3AynmhObZ8E0GTegF8l7km4=",
+      "aarch64-darwin": "sha256-WEYhmqGhGvO47i/OICJgXyqj64Wt52juJDEe7nD7HXU="
+    },
+    "webkit": {
+      "x86_64-linux": "sha256-JdNYUUJPGRZ1Mdm2yTzFshsyntNlRqZCtyicLrrUk7g=",
+      "aarch64-linux": "sha256-tQqaU1TuIfAohpMibWu9TVw9tVPZhXzYKZTZ5N7HqIk=",
+      "x86_64-darwin": "sha256-zmxdNdptFJ+8sad6HICoJRNsVNdQ0j4kKKCPX9YsBE8=",
+      "aarch64-darwin": "sha256-AbDHuUg8jLNPWur6hieDdY8Kc2+PmlXRJGD46yujam4="
+    },
+    "ffmpeg": {
+      "x86_64-linux": "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=",
+      "aarch64-linux": "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=",
+      "x86_64-darwin": "sha256-ED6noxSDeEUt2DkIQ4gNe/kL+zHVeb2AD5klBk93F88=",
+      "aarch64-darwin": "sha256-3Adnvb7zvMXKFOhb8uuj5kx0wEIFicmckYx9WLlNNf0="
+    }
+  },
+  "mcp": {
+    "version": "0.0.70",
+    "hash": "sha256-dvFFG+/cYy09RjEMDIWncTNCcyaKoKH52qweYq0HHxU=",
+    "npmDepsHash": "sha256-tyVigQYA/viB8Ycg++SfPF6WEWWulnfuJXZYOBGhhOQ="
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds support for the [Playwright MCP server](https://github.com/Microsoft/playwright-mcp) and introduces automated dependency updates with CI integration.

### New features

- **playwright-mcp package** — new flake output `#playwright-mcp` that packages the official Microsoft Playwright MCP server
- **Auto-update workflow** — daily cron job that checks for new Playwright/MCP versions, updates `flake.lock`, and creates/updates a PR with a detailed summary of changes
- **CI workflow** — runs `nix build` and `nix flake check` on Linux and macOS for every PR; auto-merges PRs labeled `auto-update` after CI passes
- **Nix flake checks** — add automated checks to validate the flake

### Cleanup

- Remove dead code (fix deadnix and statix warnings)
- Consolidate duplicate MCP config examples in README; add config file locations table
- Bump `actions/checkout` from v4 to v6

## Setup required by the repository owner

The auto-update workflow needs a Personal Access Token so that PRs it creates trigger the CI workflow (events from the default `GITHUB_TOKEN` [do not trigger other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)).

### 1. Create a fine-grained PAT

```sh
gh auth token  # verify you're authenticated

# Create a fine-grained PAT scoped to this repo with the required permissions
# This opens a browser to complete the token creation
open "https://github.com/settings/personal-access-tokens/new"
```

When creating the token:
- **Repository access**: select only this repository
- **Permissions**: `Contents: Read and write`, `Pull requests: Read and write`
- **Expiration**: choose an appropriate lifetime

### 2. Add the token as a repository secret

```sh
# You'll be prompted to paste the token value
gh secret set PAT_TOKEN --repo pietdevries94/playwright-web-flake
```

### 3. Create the `auto-update` label

The CI workflow uses this label to identify PRs eligible for auto-merge.

```sh
gh label create auto-update \
  --description "Automated dependency update" \
  --color "0E8A16" \
  --repo pietdevries94/playwright-web-flake
```

## Usage

```sh
nix shell github:pietdevries94/playwright-web-flake#playwright-mcp
```

### Claude Configuration

Add to your MCP config file:

```json
{
  "mcpServers": {
    "playwright": {
      "command": "nix",
      "args": ["shell", "github:pietdevries94/playwright-web-flake#playwright-mcp", "--command", "playwright-mcp", "--headless"]
    }
  }
}
```

| Tool | Config File Path |
|------|------------------|
| Claude Desktop | `~/.config/claude/claude_desktop_config.json` |
| Claude Code | `.mcp.json` (project root) |