### PR TITLE
fix(webkit): add enchant_2 to buildinputs

### DIFF
--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -11,6 +11,7 @@
   brotli,
   at-spi2-atk,
   cairo,
+  enchant_2,
   flite,
   fontconfig,
   freetype,
@@ -170,6 +171,7 @@ let
     buildInputs = [
       at-spi2-atk
       cairo
+      enchant_2
       flite
       fontconfig.lib
       freetype


### PR DESCRIPTION
The webkit build fails on playwright 1.61.x. The newer version requires enchant_2 as buildInput. After this fix, everything runs fine again.