### PR TITLE
fix: update libgcc dependencies

### DIFF
--- a/playwright-driver/chromium-headless-shell.nix
+++ b/playwright-driver/chromium-headless-shell.nix
@@ -58,7 +58,7 @@ let
       libXfixes
       libXrandr
       libgbm
-      libgcc.lib
+      libgcc
       libxkbcommon
       nspr
       nss

--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -191,7 +191,7 @@ let
       libdrm
       libepoxy
       libevent
-      libgcc.lib
+      libgcc
       libgcrypt
       libgpg-error
       libjpeg8


### PR DESCRIPTION
Replace libgcc.lib with libgcc in Playwright Chromium headless shell and WebKit dependencies.
Upstream: https://github.com/NixOS/nixpkgs/pull/515911
Issue: https://github.com/pietdevries94/playwright-web-flake/issues/27