### PR TITLE
fix: use Playwright Ubuntu 24.04 browser builds

### DIFF
--- a/playwright-driver/firefox.nix
+++ b/playwright-driver/firefox.nix
@@ -13,12 +13,12 @@ let
     name = "playwright-firefox";
     src = fetchzip {
       url = "https://cdn.playwright.dev/builds/firefox/${revision}/firefox-${
-        "ubuntu-22.04" + (lib.removePrefix "linux" suffix)
+        "ubuntu-24.04" + (lib.removePrefix "linux" suffix)
       }.zip";
       hash =
         {
-          x86_64-linux = "sha256-VFwdhneqr/TVgrupH27NcDXAYCBsdWtj9/qnmZAyd5E=";
-          aarch64-linux = "sha256-fcZ6hf4DY5D+54WfoJERiLdsrUjxLu3gnBVk3yhWpag=";
+          x86_64-linux = "sha256-ol9Ai8BpstZdfd6v1NDq66BjLTr/5THya0Fk2z1toJg=";
+          aarch64-linux = "sha256-G0pcHmjRj5GKsDF7iHdQyGsJCiv4gqaFv2PwGa/t8bw=";
         }
         .${system} or throwSystem;
     };

--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -21,7 +21,7 @@
   harfbuzz,
   harfbuzzFull,
   hyphen,
-  icu70,
+  icu74,
   lcms,
   libavif,
   libbacktrace,
@@ -74,7 +74,7 @@ let
 
   suffix' =
     if lib.hasPrefix "linux" suffix then
-      "ubuntu-22.04" + (lib.removePrefix "linux" suffix)
+      "ubuntu-24.04" + (lib.removePrefix "linux" suffix)
     else if lib.hasPrefix "mac" suffix then
       "mac-14" + (lib.removePrefix "mac" suffix)
     else
@@ -88,19 +88,6 @@ let
         rev = "v${finalAttrs.version}";
         sha256 = "sha256-9SFFE2GfYYMgxp1dpmL3STTU2ea1R5vFKA1L0pZwIvQ=";
       };
-    }
-  );
-  libavif' = libavif.overrideAttrs (
-    finalAttrs: previousAttrs: {
-      version = "0.9.3";
-      src = fetchFromGitHub {
-        owner = "AOMediaCodec";
-        repo = finalAttrs.pname;
-        rev = "v${finalAttrs.version}";
-        hash = "sha256-ME/mkaHhFeHajTbc7zhg9vtf/8XgkgSRu9I/mlQXnds=";
-      };
-      postPatch = "";
-      patches = [ ];
     }
   );
 
@@ -157,8 +144,8 @@ let
       stripRoot = false;
       hash =
         {
-          x86_64-linux = "sha256-QHCYfbUOcTsRm7ZKhVdRSUVmnx6Xjul3xkDSwR7XMX8=";
-          aarch64-linux = "sha256-vbMYXrpQX9r5Zcu6KnZwALhecjos53gzIy5bpiyoHWA=";
+          x86_64-linux = "sha256-GASDnneoxfZLUctJLnaUTPW4HDbKdSamJBxFDVpPUC0=";
+          aarch64-linux = "sha256-qtqMCyEZVQu44HGI73t50D1WcnuzxuxLY7MDzf4NDeA=";
         }
         .${system} or throwSystem;
     };
@@ -184,9 +171,9 @@ let
       harfbuzz
       harfbuzzFull
       hyphen
-      icu70
+      icu74
       lcms
-      libavif'
+      libavif
       libbacktrace
       libdrm
       libepoxy

--- a/update.sh
+++ b/update.sh
@@ -161,9 +161,9 @@ update_browser() {
             suffix="linux"
         elif [ "$name" = "firefox" ]; then
             stripRoot="true"
-            suffix="ubuntu-22.04"
+            suffix="ubuntu-24.04"
         else
-            suffix="ubuntu-22.04"
+            suffix="ubuntu-24.04"
         fi
     fi
     aarch64_suffix="$suffix-arm64"


### PR DESCRIPTION
Switch Linux Firefox and WebKit downloads and updater URLs to Ubuntu 24.04 binaries.
Upstream: https://github.com/NixOS/nixpkgs/commit/f445a8f8b9f5d94af222755c06a823ba9c345d60
Issue: https://github.com/pietdevries94/playwright-web-flake/issues/27