### PR TITLE
fix: move Playwright env var into env

### DIFF
--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -48,7 +48,7 @@ let
       jq
     ];
 
-    ELECTRON_SKIP_BINARY_DOWNLOAD = true;
+    env.ELECTRON_SKIP_BINARY_DOWNLOAD = true;
 
     postPatch = ''
       sed -i '/\/\/ Update test runner./,/^\s*$/{d}' utils/build/build.js


### PR DESCRIPTION
Use structuredAttrs-compatible syntax for ELECTRON_SKIP_BINARY_DOWNLOAD.
Upstream: https://github.com/NixOS/nixpkgs/pull/524082
Issue: https://github.com/pietdevries94/playwright-web-flake/issues/27