### PR TITLE
fix: make WebKit work on Linux

### DIFF
--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -52,6 +52,10 @@ let
 
     postPatch = ''
       sed -i '/\/\/ Update test runner./,/^\s*$/{d}' utils/build/build.js
+      # The dlopen library check uses ldconfig, which does not work under Nix.
+      # Libraries are already provided via rpath by autoPatchelfHook and wrapProgram.
+      substituteInPlace packages/playwright-core/src/server/registry/index.ts \
+        --replace-fail "['libGLESv2.so.2', 'libx264.so']" "[]"
     '';
 
     installPhase = ''

--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -41,7 +41,7 @@
   libwpe,
   libwpe-fdo,
   libxkbcommon,
-  libxml2,
+  libxml2_13,
   libxslt,
   libgbm,
   sqlite,
@@ -194,7 +194,7 @@ let
       libwpe
       libwpe-fdo
       libvpx'
-      libxml2
+      libxml2_13
       libxslt
       libgbm
       sqlite
@@ -214,17 +214,9 @@ let
       # remove bundled libs
       rm -rf $out/minibrowser-wpe/sys
 
-      # TODO: still fails on ubuntu trying to find libEGL_mesa.so.0
       wrapProgram $out/minibrowser-wpe/bin/MiniBrowser \
         --prefix GIO_EXTRA_MODULES ":" "${glib-networking}/lib/gio/modules/" \
         --prefix LD_LIBRARY_PATH ":" $out/minibrowser-wpe/lib
-
-    '';
-
-    preFixup = ''
-      # Fix libxml2 breakage. See https://github.com/NixOS/nixpkgs/pull/396195#issuecomment-2881757108
-      mkdir -p "$out/lib"
-      ln -s "${lib.getLib libxml2}/lib/libxml2.so" "$out/lib/libxml2.so.2"
     '';
   };
   webkit-darwin = fetchzip {


### PR DESCRIPTION
Use libxml2_13, remove Playwright’s ldconfig-based library probe, and avoid a hardcoded Mesa dependency under Nix.
Upstream: https://github.com/NixOS/nixpkgs/pull/510475
Follow-up: https://github.com/NixOS/nixpkgs/commit/e264b7c63a6c843a6b1beaa419f462dcd1be9374
Issue: https://github.com/pietdevries94/playwright-web-flake/issues/27