### PR TITLE
feat: expose custom Playwright browser selection

### DIFF
--- a/playwright-driver/driver.nix
+++ b/playwright-driver/driver.nix
@@ -103,6 +103,7 @@ let
 
     passthru = {
       browsersJSON = (lib.importJSON ./browsers.json).browsers;
+      selectBrowsers = browsers;
       browsers = browsers { };
       browsers-chromium = browsers {
         withFirefox = false;


### PR DESCRIPTION
Expose selectBrowsers passthru so consumers can build browser subsets.
Upstream: https://github.com/NixOS/nixpkgs/pull/493673
Issue: https://github.com/pietdevries94/playwright-web-flake/issues/27