### PR TITLE
fix: stabilize WebKit libjxl override

### DIFF
--- a/playwright-driver/webkit.nix
+++ b/playwright-driver/webkit.nix
@@ -114,6 +114,10 @@ let
         hash = "sha256-I3PGgh0XqRkCFz7lUZ3Q4eU0+0GwaQcVb6t4Pru1kKo=";
         fetchSubmodules = true;
       };
+      outputs = [
+        "out"
+        "dev"
+      ];
       patches = [
         # Add missing <atomic> content to fix gcc compilation for RISCV architecture
         # https://github.com/libjxl/libjxl/pull/2211


### PR DESCRIPTION
Keep only out and dev outputs when overriding libjxl for WebKit.
Upstream: https://github.com/NixOS/nixpkgs/commit/529a1fc31812b1cd93236dc2e59bcd22ba889ed2
Issue: https://github.com/pietdevries94/playwright-web-flake/issues/27